### PR TITLE
Do not error when invalid ttl label value is parsed

### DIFF
--- a/internal/ttl/ttl_test.go
+++ b/internal/ttl/ttl_test.go
@@ -136,8 +136,9 @@ func TestInvalidTtlLabelValue(t *testing.T) {
 	}
 	_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, _, err = ttlEvictionCandidate(ctx, client)
-	require.EqualError(t, err, "could not parse ttl duration: foobar")
+	_, ok, err := ttlEvictionCandidate(ctx, client)
+	require.Nil(t, err)
+	require.False(t, ok)
 }
 
 func TestMissingCreationTimestamp(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/alexflint/go-arg"
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
@@ -45,6 +46,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
+	ctx = logr.NewContext(ctx, log)
 
 	g.Go(func() error {
 		err := ttl.Run(ctx, client, cfg.Interval)


### PR DESCRIPTION
It is better to attempt to evict a node with a proper label value, rather than crash the application if an unexpected value is found. Instead it should log the error to make it visible to end users.