### PR TITLE
Respect cluster autoscaler scale down disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ metadata:
 
 The following node will be considered for eviction after it has existed for more the 24 hours.
 
+### Scale Down Disabled
+
+The cluster autoscaler annotation to [disable scale down](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-prevent-cluster-autoscaler-from-scaling-down-a-particular-node) is also respected by Node TTL. A node with the annotation will not be considered for eviction due to TTL.
+
+```yaml
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+  labels:
+    xkf.xenit.io/node-ttl: 24h
+  annotation:
+    cluster-autoscaler.kubernetes.io/scale-down-disabled: true
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/internal/ttl/ttl.go
+++ b/internal/ttl/ttl.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	NodeTtlLabelKey = "xkf.xenit.io/node-ttl"
+	NodeTtlLabelKey      = "xkf.xenit.io/node-ttl"
+	ScaleDownDisabledKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 )
 
 // ttlEvictionCandidate returns the most appropriate node to be evicted.
@@ -39,6 +40,10 @@ func ttlEvictionCandidate(ctx context.Context, client kubernetes.Interface) (*co
 		nullTime := time.Time{}
 		if node.CreationTimestamp.Time == nullTime {
 			log.Info("skipping node without creation timestamp")
+			continue
+		}
+		if value, ok := node.ObjectMeta.Annotations[ScaleDownDisabledKey]; ok && value == "true" {
+			log.Info("skipping node with disabled scale down")
 			continue
 		}
 		ttlValue, ok := node.ObjectMeta.Labels[NodeTtlLabelKey]

--- a/internal/ttl/ttl_test.go
+++ b/internal/ttl/ttl_test.go
@@ -122,6 +122,28 @@ func TestExpiredTtl(t *testing.T) {
 	}
 }
 
+func TestScaleDownDisabled(t *testing.T) {
+	ctx := context.TODO()
+	client := fake.NewSimpleClientset()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scale-down-disabled",
+			Labels: map[string]string{
+				NodeTtlLabelKey: "1m",
+			},
+			Annotations: map[string]string{
+				ScaleDownDisabledKey: "true",
+			},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+		},
+	}
+	_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, ok, err := ttlEvictionCandidate(ctx, client)
+	require.Nil(t, err)
+	require.False(t, ok)
+}
+
 func TestInvalidTtlLabelValue(t *testing.T) {
 	ctx := context.TODO()
 	client := fake.NewSimpleClientset()


### PR DESCRIPTION
This change will make Node TTL ignore any node annotated with `cluster-autoscaler.kubernetes.io/scale-down-disabled: true`. The reasoning is that anyone annotating their node with this value would expect the cluster autoscaler to not remove the node so it is reasonable that any other application should not either. This is useful for debugging purposes or other situations where one may want to keep the node from being removed.

Fixes #9 