### PR TITLE
Separate Cluster Autoscaler Kubemark build into separate action

### DIFF
--- a/.github/workflows/cluster-autoscaler.yaml
+++ b/.github/workflows/cluster-autoscaler.yaml
@@ -1,0 +1,36 @@
+name: cluster-autoscaler
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cluster-autoscaler.yaml"
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+        with:
+          repository: "kubernetes/autoscaler"
+          ref: "cluster-autoscaler-1.25.0"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Cluster Autoscaler with Kubemark
+        run: |
+          cd cluster-autoscaler
+          BUILD_TAGS=kubemark make build
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: cluster-autoscaler
+          file: ./cluster-autoscaler/Dockerfile.amd64
+          platforms: linux/amd64
+          tags: ghcr.io/xenitab/cluster-autoscaler-kubemark:1.25.0
+          labels: |
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docker-build:
 
 .PHONY: e2e
 .ONESHELL:
-e2e: docker-build docker-build-cluster-autoscaler
+e2e: docker-build
 	set -ex
 
 	TMP_DIR=$$(mktemp -d)
@@ -31,7 +31,6 @@ e2e: docker-build docker-build-cluster-autoscaler
 	# Create kind cluster and load images
 	kind create cluster --kubeconfig $$KIND_KUBECONFIG
 	kind load docker-image ${IMG}
-	kind load docker-image staging-k8s.gcr.io/cluster-autoscaler-amd64:dev
 	docker pull quay.io/elmiko/kubemark:v1.25.3
 	kind load docker-image quay.io/elmiko/kubemark:v1.25.3
 
@@ -62,12 +61,3 @@ e2e: docker-build docker-build-cluster-autoscaler
 
 	# Delete cluster
 	kind delete cluster
-
-docker-build-cluster-autoscaler:
-	TMP_DIR=$$(mktemp -d)
-	cd $$TMP_DIR
-	git clone https://github.com/kubernetes/autoscaler
-	cd autoscaler/cluster-autoscaler
-	git checkout cluster-autoscaler-1.25.0
-	BUILD_TAGS=kubemark make build
-	make make-image

--- a/e2e/cluster-autoscaler.yaml
+++ b/e2e/cluster-autoscaler.yaml
@@ -310,8 +310,7 @@ spec:
       dnsPolicy: "ClusterFirst"
       containers:
         - name: kubemark-cluster-autoscaler
-          image: "staging-k8s.gcr.io/cluster-autoscaler-amd64:dev"
-          imagePullPolicy: "Never"
+          image: "ghcr.io/xenitab/cluster-autoscaler-kubemark:1.25.0"
           command:
             - ./cluster-autoscaler
             - --cloud-provider=kubemark


### PR DESCRIPTION
E2E tests take a long time because Kubemark Cluster Autoscaler has to be built every time. This change separates the build into its own workflow.