### PR TITLE
Feature/#75

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ metadata:
     cluster-autoscaler.kubernetes.io/safe-to-evict: false
 ```
 
+### Adding Custom Node Pool Label key And Pool name
+
+If the node pool label key and pool name are different from the pre-defined values, 
+you can set the `customNodeLabelKey` and `customNodePoolNameFormat` values in the `values.yaml` file.
+
+```yaml
+customNodeLabelKey: "cloud.google.com/gke-nodepool" # Required
+customNodePoolNameFormat: "example-%s" # Optional (default: "%s")
+```
+
+or use the env variables `CUSTOM_NODE_POOL_LABEL_KEY` and `CUSTOM_NODE_POOL_NAME_FORMAT` to set the values. 
+
+```shell
+CUSTOM_NODE_POOL_LABEL_KEY=cloud.google.com/gke-nodepool
+CUSTOM_NODE_POOL_NAME_FORMAT=example-%s
+```
+
 ### Cluster Autoscaler Status
 
 A node pool where the min count is equal to the current node count will node be scaled down by cluster autoscaler. Even if the node is completely unused and a scale down candidate. This is because the cluster austoscaler has to fulfill the minum count requirement. This is an issue for Node TTL as it relies on cluster autoscaler node removal to replace nodes. If a node in this case were to be cordoned and drained the node would get stuck forever without any Pods scheduled to it. In a perfect world cluster autoscaler would allow the node removal and create a new node or alternativly preemptivly add a new node to the node pool.

--- a/charts/node-ttl/Chart.yaml
+++ b/charts/node-ttl/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-ttl
 description: Enforces a time to live (TTL) on Kubernetes nodes and evicts nodes which have expired.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1

--- a/charts/node-ttl/README.md
+++ b/charts/node-ttl/README.md
@@ -4,22 +4,24 @@ Enforces a time to live (TTL) on Kubernetes nodes and evicts nodes which have ex
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/xenitab/node-ttl"` |  |
-| image.tag | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| nodeTtl.interval | string | `"10m"` |  |
-| podAnnotations | object | `{}` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| resources | object | `{}` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
-| securityContext.runAsUser | int | `65532` |  |
-| tolerations | list | `[]` |  |
+| Key                                    | Type   | Default                      | Description                                                                                                                                                                                   |
+|----------------------------------------|--------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| affinity                               | object | `{}`                         |                                                                                                                                                                                               |
+| fullnameOverride                       | string | `""`                         |                                                                                                                                                                                               |
+| image.pullPolicy                       | string | `"IfNotPresent"`             |                                                                                                                                                                                               |
+| image.repository                       | string | `"ghcr.io/xenitab/node-ttl"` |                                                                                                                                                                                               |
+| image.tag                              | string | `""`                         |                                                                                                                                                                                               |
+| imagePullSecrets                       | list   | `[]`                         |                                                                                                                                                                                               |
+| nameOverride                           | string | `""`                         |                                                                                                                                                                                               |
+| nodeSelector                           | object | `{}`                         |                                                                                                                                                                                               |
+| nodeTtl.interval                       | string | `"10m"`                      |                                                                                                                                                                                               |
+| podAnnotations                         | object | `{}`                         |                                                                                                                                                                                               |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"`           |                                                                                                                                                                                               |
+| resources                              | object | `{}`                         |                                                                                                                                                                                               |
+| securityContext.capabilities.drop[0]   | string | `"ALL"`                      |                                                                                                                                                                                               |
+| securityContext.readOnlyRootFilesystem | bool   | `true`                       |                                                                                                                                                                                               |
+| securityContext.runAsNonRoot           | bool   | `true`                       |                                                                                                                                                                                               |
+| securityContext.runAsUser              | int    | `65532`                      |                                                                                                                                                                                               |
+| tolerations                            | list   | `[]`                         |                                                                                                                                                                                               |
+| customNodeLabelKey                     | string | ``                           | Must be set to a non-empty value to enable custom node label                                                                                                                                  |
+| customNodePoolNameFormat               | string | ``                           | It should be a format string with one %s to be replaced by the custom node label value (e.g. "node-pool-%s") with optional regexp to match the node pool name against (e.g. "node-pool-(.*)") |

--- a/charts/node-ttl/templates/deployment.yaml
+++ b/charts/node-ttl/templates/deployment.yaml
@@ -28,6 +28,17 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.customNodeLabelKey }}
+          env:
+            {{- if .Values.customNodeLabelKey }}
+            - name: CUSTOM_NODE_POOL_LABEL_KEY
+              value: {{ .Values.customNodeLabelKey }}
+            {{- end }}
+            {{- if .Values.customNodePoolNameFormat }}
+            - name: CUSTOM_NODE_POOL_NAME_FORMAT
+              value: {{ .Values.customNodePoolNameFormat }}
+            {{- end }}
+          {{- end }}
           args:
             - --probe-addr=:{{ .Values.service.probe.port }}
             - --metrics-addr=:{{ .Values.service.metrics.port }}

--- a/charts/node-ttl/values.yaml
+++ b/charts/node-ttl/values.yaml
@@ -46,3 +46,8 @@ nodeTtl:
   interval: 10m
   statusConfigMapName: cluster-autoscaler-status
   statusConfigMapNamespace: cluster-autoscaler
+
+customNodeLabelKey: "" # Must be set to a non-empty value to enable custom node label
+# it should be a format string with one %s to be replaced by the custom node label value (e.g. "node-pool-%s")
+# with optional regexp to match the node pool name against (e.g. "node-pool-(.*)")
+customNodePoolNameFormat: "" # default: "%s"

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -172,6 +172,15 @@ func getNodePoolNameAndNode(t *testing.T, cp string, name string) (*corev1.Node,
 				},
 			},
 		}, name
+	case CustomNodeLabelKey:
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					CustomNodeLabelKey: name,
+				},
+			},
+		}, fmt.Sprintf("custom-%s", name)
 	default:
 		t.Fatal("unknown key")
 		return nil, ""

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -1,0 +1,11 @@
+package utils
+
+import "os"
+
+// GetEnvOrDefault returns the value of the environment variable with the given key, or the given default value if the env is not set.
+func GetEnvOrDefault(key, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/utils/env_test.go
+++ b/internal/utils/env_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGetEnvOrDefault(t *testing.T) {
+	// Set an environment variable for testing
+	err := os.Setenv("TEST_KEY", "TEST_VALUE")
+	assert.Nil(t, err)
+
+	// Test case when the environment variable exists
+	value := GetEnvOrDefault("TEST_KEY", "DEFAULT_VALUE")
+	if value != "TEST_VALUE" {
+		t.Errorf("Expected TEST_VALUE, but got %s", value)
+	}
+
+	// Test case when the environment variable does not exist
+	value = GetEnvOrDefault("NON_EXISTENT_KEY", "DEFAULT_VALUE")
+	if value != "DEFAULT_VALUE" {
+		t.Errorf("Expected DEFAULT_VALUE, but got %s", value)
+	}
+
+	// Unset the environment variable after testing
+	err = os.Unsetenv("TEST_KEY")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
As it mentioned in https://github.com/XenitAB/node-ttl/issues/75 

This PR add the possibility to use user defined node pool labels and user defined node pool name formats.

- Add the logic to the app
- Extends Helm with the new configurations (update chart version to 0.1.1)
-  Extend docs with the new feature
- Extend test cases