### PR TITLE
fix: node-ttl broken since cluster autoscaler v1.30.0

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -23,16 +23,16 @@ func TestCapcityCheck(t *testing.T) {
 	client, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)
 
-  require.Never(t, func() bool {
-    nodeList, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "xkf.xenit.io/node-ttl"})
-    require.NoError(t, err)
-    for _, node := range nodeList.Items {
-      t.Log("checking that node is not evicted", node.Name)
+	require.Never(t, func() bool {
+		nodeList, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "xkf.xenit.io/node-ttl"})
+		require.NoError(t, err)
+		for _, node := range nodeList.Items {
+			t.Log("checking that node is not evicted", node.Name)
 			// TODO: There should be a better way to check that eviction is due to node ttl
-      return node.Spec.Unschedulable
-    }
-    return false
-  }, 1 * time.Minute, 5 * time.Second)
+			return node.Spec.Unschedulable
+		}
+		return false
+	}, 1*time.Minute, 5*time.Second)
 }
 
 func TestTTLEviction(t *testing.T) {
@@ -66,7 +66,7 @@ func TestTTLEviction(t *testing.T) {
 				return false
 			}
 			return true
-		}, 1*time.Minute, 1*time.Second, "node should be evicted due to TTL")
+		}, 2*time.Minute, 1*time.Second, "node should be evicted due to TTL")
 		t.Log("node has been marked unschedulable by node ttl", node.Name)
 
 		require.Eventually(t, func() bool {

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
+	github.com/goccy/go-yaml v1.17.1
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZ
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=


### PR DESCRIPTION
This PR adds a fix that deals with the changed format of the cluster autoscaler configmap which was introduced in v1.30.0.